### PR TITLE
Update signal levels even when srx is disabled

### DIFF
--- a/src/svxlink/trx/Voter.cpp
+++ b/src/svxlink/trx/Voter.cpp
@@ -669,10 +669,11 @@ void Voter::satSquelchOpen(bool is_open, SatRx *srx)
 
 void Voter::satSignalLevelUpdated(float siglev, SatRx *srx)
 {
-  if (srx->isEnabled())
-  {
+  // https://github.com/sm0svx/svxlink/issues/608
+  //if (srx->isEnabled())
+  //{
     dispatchEvent(Macho::Event(&Top::satSignalLevelUpdated, srx, siglev));
-  }
+  //}
 } /* Voter::satSignalLevelUpdated */
 
 

--- a/src/svxlink/trx/Voter.cpp
+++ b/src/svxlink/trx/Voter.cpp
@@ -670,10 +670,11 @@ void Voter::satSquelchOpen(bool is_open, SatRx *srx)
 void Voter::satSignalLevelUpdated(float siglev, SatRx *srx)
 {
   // https://github.com/sm0svx/svxlink/issues/608
-  //if (srx->isEnabled())
-  //{
+  // removing the if here, causes an assert to fail below
+  if (srx->isEnabled())
+  {
     dispatchEvent(Macho::Event(&Top::satSignalLevelUpdated, srx, siglev));
-  //}
+  }
 } /* Voter::satSignalLevelUpdated */
 
 

--- a/src/svxlink/trx/Voter.cpp
+++ b/src/svxlink/trx/Voter.cpp
@@ -723,12 +723,13 @@ void Voter::printSquelchState(void)
     char rx_id = srx->id();
     rx["id"] = std::string(&rx_id, &rx_id+1);
     rx["enabled"] = is_enabled;
-    if (is_enabled)
-    {
+    // https://github.com/sm0svx/svxlink/issues/608
+    // if (is_enabled)
+    // {
       rx["sql_open"] = sql_is_open;
       rx["active"] = is_active;
       rx["siglev"] = static_cast<int>(siglev);
-    }
+    // }
     event.append(rx);
   }
   Json::StreamWriterBuilder builder;


### PR DESCRIPTION
Otherwise, traffic on the srx won't be visible. This makes it impossible to see if any QRM is still there.
https://github.com/sm0svx/svxlink/issues/608