### PR TITLE
close sql on mute

### DIFF
--- a/src/svxlink/trx/NetRx.cpp
+++ b/src/svxlink/trx/NetRx.cpp
@@ -250,6 +250,9 @@ void NetRx::setMuteState(Rx::MuteState new_mute_state)
           {
             audio_dec->flushEncodedSamples();
           }
+          // WIM close sql on mute
+          sql_is_open = false;
+          setSquelchState(false, "MUTED");
           break;
 
         case MUTE_ALL:  // MUTE_CONTENT -> MUTE_ALL


### PR DESCRIPTION
Fixes these:

|       | audio | trx |    |
| --- | --- | --- | --- |
|ch1=open/EN; ch2=closed/EN	|	ch1	|ON	 ||
|ch1=open/MU; ch2=closed/EN	|	--	|ON	||
|ch1=closed/MU; ch2=closed/EN	|	--	|OFF|	trx turns off only when selected muted rx closes|
| | | | |				
|ch1=open/EN; ch2=closed/EN	|	ch1	|ON	||
|ch1=open/MU; ch2=closed/EN	|	--	|ON	||
|ch1=open/MU; ch2=open/EN	|	--	|ON	|voter does not switch to ch2|
|||||				
|ch1=open/EN; ch2=closed/EN	|	ch1	|ON	||
|ch1=open/MU; ch2=closed/EN	|	--	|ON	||
|ch1=open/MU; ch2=open/EN	|	--	|ON	|voter does not switch to ch2|
|ch1=closed/MU; ch2=open/EN	|	ch2|	ON|	now voter switches to ch2|